### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/List/Utils.pm
+++ b/lib/List/Utils.pm
@@ -1,4 +1,4 @@
-module List::Utils;
+unit module List::Utils;
 
 sub push-one-take-if-enough(@values is rw, $new-value, $n) {
     @values.push($new-value);


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.