### PR TITLE
Make tests pass by making stuff eager

### DIFF
--- a/lib/List/Utils.pm
+++ b/lib/List/Utils.pm
@@ -61,7 +61,7 @@ multi sub combinations(@items, $count) is export {
     my $size = +@items;
     my $top = $size - $count;
     my @indicies = (^$count).list;
-    gather loop {
+    eager gather loop { # TODO should it be eager?
         take [@items[@indicies]];
         last if !@indicies || @indicies[0] == $top;
         for $count - 1 ... 0 -> $i {


### PR DESCRIPTION
It looks like rakudo used to return a List there, but now it returns
a Seq. For some reason (maybe a good one) tests are trying to ensure
that a List is returned, so I added `eager` to satisfy that. That
being said, I think some of these tests should be dropped.